### PR TITLE
misspelled trait name

### DIFF
--- a/src/DisableEnsureParentDirectories.php
+++ b/src/DisableEnsureParentDirectories.php
@@ -2,7 +2,7 @@
 
 namespace Hypweb\Flysystem\Cached\Extra;
 
-trait disableEnsureParentDirectories
+trait DisableEnsureParentDirectories
 {
     /**
      * Disabled Ensure parent directories of an object.


### PR DESCRIPTION
makes problems with autoloading